### PR TITLE
Update .io to .org

### DIFF
--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -7,12 +7,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta property="og:title" content="{{page.title}}">
     <meta property="og:type" content="website">
-    <meta property="og:image" content="{% if page.imageUrl %}{{page.imageUrl}}{% else %}https://sandstorm.io/images/sandcat.png{% endif %}">
-    <meta property="og:url" content="https://sandstorm.io{{page.url}}">
+    <meta property="og:image" content="{% if page.imageUrl %}{{page.imageUrl}}{% else %}https://sandstorm.org/images/sandcat.png{% endif %}">
+    <meta property="og:url" content="https://sandstorm.org{{page.url}}">
     <meta property="og:description"
         content="Take control of your web by running your own personal cloud server with Sandstorm.">
     <link rel="stylesheet" type="text/css" href="/style.css">
-    <link rel="alternate" type="application/rss+xml" title="Sandstorm.io Blog" href="{{site.baseurl}}feed.xml">
+    <link rel="alternate" type="application/rss+xml" title="Sandstorm News" href="{{site.baseurl}}feed.xml">
     <link rel="me" href="https://floss.social/@sandstorm">
   </head>
 
@@ -24,11 +24,11 @@
 
   <body id="{{bodyid}}">
     <nav>
-      <a href="/">Sandstorm.io</a>
+      <a href="/">Sandstorm</a>
       <a href="/get">Get Sandstorm</a>
       <a href="/features">Features</a>
       <a href="/how-it-works">Technology</a>
-      <a href="/news/">Blog</a>
+      <a href="/news/">News</a>
       <a href="https://docs.sandstorm.io">Docs</a>
       <a href="https://github.com/sandstorm-io/sandstorm">Code</a>
       <a href="/community">Community</a>

--- a/feed.xml
+++ b/feed.xml
@@ -5,18 +5,18 @@ layout: none
 <?xml version="1.0" encoding="UTF-8"?>
 <rss version="2.0" xmlns:atom="http://www.w3.org/2005/Atom" xmlns:dc="http://purl.org/dc/elements/1.1/">
 	<channel>
-		<title>Sandstorm.io Blog</title>
-		<description>Latest updates on Sandstorm.io</description>		
-		<link>https://sandstorm.io</link>
+		<title>Sandstorm News</title>
+		<description>Latest updates on Sandstorm</description>		
+		<link>https://sandstorm.org</link>
 		<atom:link href="{{ site.baseurl }}feed.xml" rel="self" type="application/rss+xml" />
 		{% for post in site.posts limit:10 %}
 			<item>
 				<title>{{ post.title | xml_escape }}</title>
 				<description>{{ post.content | xml_escape }}</description>
 				<pubDate>{{ post.date | date: "%a, %d %b %Y %H:%M:%S %z" }}</pubDate>
-                                <link>https://sandstorm.io{{ post.url }}</link>
+                                <link>https://sandstorm.org{{ post.url }}</link>
                                 <dc:creator>{{ post.author | xml_escape }}</dc:creator>
-                                <guid isPermaLink="true">https://sandstorm.io{{ post.url }}</guid>
+                                <guid isPermaLink="true">https://sandstorm.org{{ post.url }}</guid>
 			</item>
 		{% endfor %}
 	</channel>

--- a/install.html
+++ b/install.html
@@ -8,7 +8,7 @@ title: Install Sandstorm
 
 <header>
   <div>
-    <h1>Sandstorm.io</h1>
+    <h1>Sandstorm</h1>
     <p>INSTALL INSTRUCTIONS</p>
   </div>
 </header>


### PR DESCRIPTION
Couple things are broken, so this PR will begin to fix that. In branding-areas, we will remove .io and just begin to call it "Sandstorm".