### PR TITLE
Replace paginate, update Gemfile

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,7 @@ gem 'guard'
 gem 'guard-jekyll-plus'
 gem 'guard-livereload'
 gem 'octopress-autoprefixer'
-gem 'jekyll-paginate'
+
+group :jekyll_plugins do
+  gem "jekyll-paginate-v2", "~> 3.0"
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -16,6 +16,7 @@ GEM
     ffi (1.16.3)
     formatador (1.1.0)
     forwardable-extended (2.6.0)
+    google-protobuf (3.24.4)
     guard (2.18.1)
       formatador (>= 0.2.4)
       listen (>= 2.7, < 4.0)
@@ -54,9 +55,10 @@ GEM
       safe_yaml (~> 1.0)
       terminal-table (>= 1.8, < 4.0)
       webrick (~> 1.7)
-    jekyll-paginate (1.1.0)
-    jekyll-sass-converter (2.2.0)
-      sassc (> 2.0.1, < 3.0)
+    jekyll-paginate-v2 (3.0.0)
+      jekyll (>= 3.0, < 5.0)
+    jekyll-sass-converter (3.0.0)
+      sass-embedded (~> 1.54)
     jekyll-watch (2.2.1)
       listen (~> 3.0)
     kramdown (2.4.0)
@@ -86,15 +88,17 @@ GEM
     pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    public_suffix (4.0.7)
+    public_suffix (5.0.3)
+    rake (13.0.6)
     rb-fsevent (0.11.2)
     rb-inotify (0.10.1)
       ffi (~> 1.0)
     rexml (3.2.6)
-    rouge (3.30.0)
+    rouge (4.1.3)
     safe_yaml (1.0.5)
-    sassc (2.4.0)
-      ffi (~> 1.9)
+    sass-embedded (1.69.3)
+      google-protobuf (~> 3.23)
+      rake (>= 13.0.0)
     shellany (0.0.1)
     terminal-table (3.0.2)
       unicode-display_width (>= 1.1.1, < 3)
@@ -110,8 +114,8 @@ DEPENDENCIES
   guard-jekyll-plus
   guard-livereload
   jekyll
-  jekyll-paginate
+  jekyll-paginate-v2 (~> 3.0)
   octopress-autoprefixer
 
 BUNDLED WITH
-   2.3.26
+   2.4.20

--- a/_config.yml
+++ b/_config.yml
@@ -1,7 +1,6 @@
 baseurl: /
+url: https://sandstorm.org
 permalink: /news/:year-:month-:day-:title
-paginate: 5
-paginate_path: "/news/page:num"
 kramdown:
   syntax_highlighter: none
 exclude:
@@ -14,4 +13,12 @@ exclude:
   - vendor
 gems:
   - octopress-autoprefixer
-  - jekyll-paginate
+plugins:
+  - jekyll-paginate-v2
+pagination:
+  enabled: true
+  debug: true
+  per_page: 5
+  permalink: /page:num/
+  sort_field: 'date'
+  sort_reverse: true

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -1,12 +1,12 @@
 ---
 layout: page
 id: blog
-title: Sandstorm Blog
+title: Sandstorm News
 ---
 
 <header>
   <div class="sand">
-    <h1>Sandstorm Blog</h1>
+    <h1>Sandstorm News</h1>
   </div>
 </header>
 

--- a/news/index.html
+++ b/news/index.html
@@ -1,12 +1,14 @@
 ---
 layout: page
 id: blog
-title: Sandstorm Blog
+title: Sandstorm News
+pagination:
+  enabled: true
 ---
 
 <header>
   <div class="sand">
-    <h1>Sandstorm Blog</h1>
+    <h1>Sandstorm News</h1>
   </div>
 </header>
 


### PR DESCRIPTION
The /news endpoint doesn't work, and I believe it's because jekyll-paginate is deprecated. A backwards compatible v2 is available though, so hopefully this will fix it.