### PR TITLE
Rename mailing list, remove productivity

### DIFF
--- a/community.html
+++ b/community.html
@@ -21,7 +21,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li><a class="fediverse" href="https://floss.social/@sandstorm">Fediverse</a>
     <li><a class="github" href="https://github.com/sandstorm-io/sandstorm">GitHub</a>
     <li><a class="livechat" href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">Live Chat</a>
-    <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Dev Group</a>
+    <li><a class="devgroup" href="https://groups.google.com/group/sandstorm-dev">Mailing List</a>
     <li><a class="youtube" href="https://www.youtube.com/channel/UC8xKZRW86Fa9W00uAppBXXg">YouTube</a>
   </ul>
 </section>
@@ -34,7 +34,7 @@ We're so glad you're interested in getting involved! We're a movement of app mak
     <li class="talk"><h3>Give a Talk</h3>
       <p>Get started with our <a href="https://github.com/sandstorm-io/sandstorm/wiki/Speaker-Kit-Lightning-Talk">speaker kit</a> to prepare your presentation. <a href="https://groups.google.com/group/sandstorm-dev">Send us an email</a> if you need help with finding a venue or preparing for your talk. We'll also send you some sandcat stickers to give out!</p>
     <li class="discuss"><h3>Discuss &amp; Answer Questions</h3>
-      <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">sandstorm-dev group</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">#sandstorm on libera.chat</a>), with <a href="https://libera.irclog.whitequark.org/sandstorm/">chat archives</a> available too.</p>
+      <p>Development and user help happens on the <a href="https://groups.google.com/group/sandstorm-dev">mailing list</a>; join us and contribute! Real-time chat happens in IRC (<a href="https://kiwiirc.com/client/irc.libera.chat/?channel=#sandstorm">#sandstorm on libera.chat</a>), with <a href="https://libera.irclog.whitequark.org/sandstorm/">chat archives</a> available too.</p>
     <li class="write"><h3>Write a Blog Post</h3>
       <p>Share your Sandstorm experiences with the world by writing a blog post. Send us a link and we'll share it with the community.</p>
   </ul>

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@ title: Sandstorm
 <!--===================================================================================-->
 
 <section id="what">
-  <h2>Self-host web-based productivity apps easily and securely.</h2>
+  <h2>Self-host web apps easily and securely.</h2>
   <p>Sandstorm is an open source project built by a community of volunteers with the goal of making
     it really easy to run open source web applications.</p>
   <ul>


### PR DESCRIPTION
Just two nits here:
- We aren't a "productivity suite" anymore, lots of apps are outside that boundary.
- Calling the mailing list the "dev group" discourages users from joining. Let's fix that.