### PR TITLE
Add OpenCollective backers

### DIFF
--- a/about.html
+++ b/about.html
@@ -212,6 +212,7 @@ title: About Sandstorm
     <li>Eli Bendersky</li>
     <li>Eli Willaert</li>
     <li>Emily Dirsh</li>
+    <li>Eric W.</li>
     <li>Erica Baker</li>
     <li>Erik Andersson</li>
     <li>Erika Rice Scherpelz</li>
@@ -234,6 +235,7 @@ title: About Sandstorm
     <li>Fred Smith</li>
     <li>Freedeb</li>
     <li>Friedrich Große</li>
+    <li>frigginGlorious</li>
     <li>Gabriel Wilkins</li>
     <li>Gabriela You (Campedelli)</li>
     <li>Gaelen Hadlett</li>
@@ -265,9 +267,11 @@ title: About Sandstorm
     <li>Håvard Kvålen</li>
     <li>Hayden Morgan</li>
     <li>Henning Koch</li>
+    <li>HLedger</li>
     <li>Hourann Bosci</li>
     <li>Hugo Artur Weber Schmitt</li>
     <li>HumanWeb Networks</li>
+    <li>Ian Denhardt</li>
     <li>Ian Henderson</li>
     <li>Ian Young</li>
     <li>Igor Cananea</li>
@@ -322,6 +326,7 @@ title: About Sandstorm
     <li>Jihyeok Seo</li>
     <li>Jimb Esser</li>
     <li class="long">Jim Garrison and Misha Karbelnig</li>
+    <li>jlev</li>
     <li>Joakim</li>
     <li>Jochen Bartl</li>
     <li>Joe Hayashi</li>
@@ -539,6 +544,7 @@ title: About Sandstorm
     <li>Sebastian Schaetz</li>
     <li>Sergey Lungu</li>
     <li>Sérgio Ramos</li>
+    <li>Seth Poovey</li>
     <li>Shane Gould</li>
     <li>Sharon Paryani</li>
     <li>Shaun Collins</li>
@@ -553,6 +559,7 @@ title: About Sandstorm
     <li>Simon Clausen</li>
     <li>Sing Li</li>
     <li>slava@meteor.com</li>
+    <li>Sönke Klimenko</li>
     <li>Steve Freeman</li>
     <li>Steve Phillips</li>
     <li>Strick Yak</li>


### PR DESCRIPTION
This adds financial contributors to the OpenCollective who didn't already have an entry in the backers list to our backers list. I am using the publicly available names for them as shown on OSC, so these are the names they have publicly decided to display as backers.