### PR TITLE
Recommend Debian

### DIFF
--- a/install.html
+++ b/install.html
@@ -36,8 +36,8 @@ title: Install Sandstorm
 
     <p>
       If you don't already have somewhere to run Sandstorm,
-      consider creating a 64-bit Ubuntu LTS virtual machine
-      on your favorite cloud provider.
+      consider creating a 64-bit Debian virtual machine on
+      your favorite cloud provider.
     </p>
   </section>
   


### PR DESCRIPTION
Sort of related to https://github.com/sandstorm-io/sandstorm/issues/3712 but in general I think for Sandstorm's case, Debian is a better distro to recommend which is lacking a lot of stuff you will never want nor need on a Sandstorm server. We do our vagrant-spk work with Debian, and it's likely the best-tested distro for Sandstorm.