### PR TITLE
Add go/tempest

### DIFF
--- a/go/tempest.html
+++ b/go/tempest.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+
+<html>
+  <head>
+    <meta name="go-import" content="sandstorm.org/go/tempest git https://github.com/sandstorm-org/tempest">
+  </head>
+  <body>
+Nothing to see here!
+  </body>
+</html>


### PR DESCRIPTION
This page will help Go applications find sandstorm.org/go/tempest including vendored components.