### PR TITLE
Removed color gradient from zulip.svg to make it match other svg icons on sandstorm.org/community page

### DIFF
--- a/images/zulip.svg
+++ b/images/zulip.svg
@@ -45,11 +45,11 @@
        gradientUnits="userSpaceOnUse">
       <stop
          offset="0"
-         stop-color="#50adff"
+         stop-color="#5b4f8c"
          id="stop2" />
       <stop
          offset="1"
-         stop-color="#7877fc"
+         stop-color="#5b4f8c"
          id="stop4" />
     </linearGradient>
   </defs>


### PR DESCRIPTION
Updated zulip.svg colors to match color scheme of other icons (#5b4f8c)