### PR TITLE
Testing a fix for go modules

### DIFF
--- a/go/tempest/capnp/api-session.html
+++ b/go/tempest/capnp/api-session.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/api-session git https://github.com/sandstorm-org/tempest.git/capnp/api-session">
+    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/api-session git https://github.com/sandstorm-org/tempest.git capnp/api-session">
     <meta http-equiv="refresh" content="0;URL='https://github.com/sandstorm-org/tempest'">
   </head>
   <body>

--- a/go/tempest/capnp/appid-replacements-test.html
+++ b/go/tempest/capnp/appid-replacements-test.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/appid-replacements-test git https://github.com/sandstorm-org/tempest.git/capnp/appid-replacements-test">
+    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/appid-replacements-test git https://github.com/sandstorm-org/tempest.git capnp/appid-replacements-test">
     <meta http-equiv="refresh" content="0;URL='https://github.com/sandstorm-org/tempest'">
   </head>
   <body>

--- a/go/tempest/capnp/appid-replacements.html
+++ b/go/tempest/capnp/appid-replacements.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/appid-replacements git https://github.com/sandstorm-org/tempest.git/capnp/appid-replacements">
+    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/appid-replacements git https://github.com/sandstorm-org/tempest.git capnp/appid-replacements">
     <meta http-equiv="refresh" content="0;URL='https://github.com/sandstorm-org/tempest'">
   </head>
   <body>

--- a/go/tempest/capnp/collection.html
+++ b/go/tempest/capnp/collection.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/collection git https://github.com/sandstorm-org/tempest.git/capnp/collection">
+    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/collection git https://github.com/sandstorm-org/tempest.git capnp/collection">
     <meta http-equiv="refresh" content="0;URL='https://github.com/sandstorm-org/tempest'">
   </head>
   <body>

--- a/go/tempest/capnp/index.html
+++ b/go/tempest/capnp/index.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <meta name="go-import" content="sandstorm.org/go/tempest/capnp/activity git https://github.com/sandstorm-org/tempest.git capnp/activity">
+    <meta name="go-import" content="sandstorm.org/go/tempest/capnp git https://github.com/sandstorm-org/tempest.git capnp">
     <meta http-equiv="refresh" content="0;URL='https://github.com/sandstorm-org/tempest'">
   </head>
   <body>

--- a/go/tempest/index.html
+++ b/go/tempest/index.html
@@ -2,7 +2,7 @@
 
 <html>
   <head>
-    <meta name="go-import" content="sandstorm.org/go/tempest git https://github.com/sandstorm-org/tempest">
+    <meta name="go-import" content="sandstorm.org/go/tempest git https://github.com/sandstorm-org/tempest.git">
     <meta http-equiv="refresh" content="0;URL='https://github.com/sandstorm-org/tempest'">
   </head>
   <body>


### PR DESCRIPTION
I'm getting closer to a fix.  This is the current error message:

```
go: sandstorm.org/go/tempest/capnp imports
	sandstorm.org/go/tempest/capnp/activity: cannot find module providing package sandstorm.org/go/tempest/capnp/activity: module sandstorm.org/go/tempest/capnp/activity: git ls-remote -q origin in /home/user/Projects/sandstorm-org/tempest/toolchain/gopath-1.24.3/pkg/mod/cache/vcs/1fdd46c93da121c092ec5130238a7dcf456fa92323d93e2ca39ad5c34f8e3ea4: exit status 128:
	remote: Not Found
	fatal: repository 'https://github.com/sandstorm-org/tempest.git/capnp/activity/' not found
```

I think that I just need to fix the path…